### PR TITLE
Fix issue #90, and avoid binding between storm and storm-kafka

### DIFF
--- a/recipes/storm/storm-0.9.2_openbus-0.0.1-r1/rpm/sources/storm-kafka-dependencies.patch
+++ b/recipes/storm/storm-0.9.2_openbus-0.0.1-r1/rpm/sources/storm-kafka-dependencies.patch
@@ -1,6 +1,6 @@
 --- apache-storm-0.9.2-incubating-vanilla/external/storm-kafka/pom.xml	2014-06-13 22:35:14.000000000 +0200
-+++ apache-storm-0.9.2-incubating/external/storm-kafka/pom.xml	2014-08-06 12:27:44.989697460 +0200
-@@ -25,19 +25,50 @@
++++ apache-storm-0.9.2-incubating/external/storm-kafka/pom.xml	2014-08-12 09:53:39.486915032 +0200
+@@ -25,19 +25,51 @@
          <relativePath>../../pom.xml</relativePath>
      </parent>
  
@@ -40,6 +40,7 @@
 +		                    <exclude>org.jboss.netty:netty</exclude>
 +		                    <exclude>com.google.guava:guava</exclude>
 +		                    <exclude>jline:jline</exclude>
++		                    <exclude>org.slf4j:slf4j-simple</exclude>
 +		                </excludes>
 +	                    </artifactSet>
 +	                    <minimizeJar>true</minimizeJar>
@@ -55,7 +56,7 @@
              <groupId>org.mockito</groupId>
              <artifactId>mockito-all</artifactId>
              <version>1.9.0</version>
-@@ -94,10 +125,8 @@
+@@ -94,10 +126,8 @@
          </dependency>
          <dependency>
              <groupId>org.apache.kafka</groupId>

--- a/recipes/storm/storm-0.9.2_openbus-0.0.1-r1/rpm/specs/storm.spec
+++ b/recipes/storm/storm-0.9.2_openbus-0.0.1-r1/rpm/specs/storm.spec
@@ -28,6 +28,8 @@
 %define storm_base_version 0.9.2
 %define storm_release openbus0.0.1_1
 
+%define kafka_version 0.8.0
+
 Name: %{storm_name}
 Version: %{storm_version}
 Release: %{storm_release}
@@ -142,7 +144,17 @@ getent passwd %{storm_user} >/dev/null || /usr/sbin/useradd --comment "Storm Dae
 %defattr(-,%{storm_user},%{storm_group})
 %dir %attr(755, root, root) %{storm_home}
 %dir %attr(755, root, root) /etc/storm
-%{storm_home}/*
+%{storm_home}/CHANGELOG.md
+%{storm_home}/DISCLAIMER
+%{storm_home}/LICENSE
+%{storm_home}/NOTICE
+%{storm_home}/README.markdown
+%{storm_home}/RELEASE
+%{storm_home}/conf/*
+%{storm_home}/examples/*
+%{storm_home}/lib/*
+%{storm_home}/logback/*
+%{storm_home}/public/*
 /etc/storm/*
 /etc/default/storm
 /var/log/*


### PR DESCRIPTION
Storm-kafka uber jar exclude slf4j-simple to avoid binding classes. Storm package will not include storm-kafka jar (duplicated files)

This commit is related with issue #90
