### PR TITLE
Fix package issues

### DIFF
--- a/recipes/storm/storm-0.9.2_openbus-0.0.1-r1/rpm/sources/install_storm.sh
+++ b/recipes/storm/storm-0.9.2_openbus-0.0.1-r1/rpm/sources/install_storm.sh
@@ -32,7 +32,6 @@ OPTS=$(getopt \
   -l 'prefix:' \
   -l 'build-dir:' \
   -l 'man-dir:' \
-  -l 'bin-dir:' \
   -l 'initd-dir:' \
   -l 'doc-dir:' \
   -- "$@")
@@ -80,6 +79,7 @@ for var in PREFIX BUILD_DIR; do
   fi
 done
 
+
 STORM_HOME=${STORM_HOME:-$PREFIX/usr/lib/storm}
 BIN_DIR=${BIN_DIR:-$PREFIX/usr/bin}
 STORM_ETC_DIR=${STORM_ETC_DIR:-$PREFIX/etc/storm}
@@ -123,8 +123,8 @@ install    -m 644 ${BUILD_DIR}/public/templates/* ${STORM_HOME}/public/templates
 install -d -m 755 ${STORM_HOME}/examples/
 install    -m 644 ${BUILD_DIR}/examples/storm-starter/*.jar ${STORM_HOME}/examples/
 
-install -d -m 755 ${STORM_ETC_DIR}
-install    -m 644 ${BUILD_DIR}/conf/* ${STORM_ETC_DIR}/
+install -d -m 755 ${STORM_ETC_DIR}/conf
+install    -m 644 ${BUILD_DIR}/conf/* ${STORM_ETC_DIR}/conf/
 
 echo ${INITD_DIR}
 install -d -m 755 ${INITD_DIR}
@@ -145,3 +145,10 @@ install    -m 644 $RPM_SOURCE_DIR/storm.nofiles.conf ${PREFIX}/etc/security/limi
 
 install -d -m 755 ${PREFIX}/var/log/storm
 install -d -m 755 ${PREFIX}/var/run/storm/
+install    -m 755 $RPM_SOURCE_DIR/storm-supervisor-bash_profile ${PREFIX}/var/run/storm/.bash_profile
+
+
+install -d -m 755 ${PREFIX}/
+
+cd ${PREFIX}/etc/storm
+ln -s conf.dist conf

--- a/recipes/storm/storm-0.9.2_openbus-0.0.1-r1/rpm/sources/storm-drpc.init
+++ b/recipes/storm/storm-0.9.2_openbus-0.0.1-r1/rpm/sources/storm-drpc.init
@@ -36,7 +36,7 @@ fi
 
 start() {
   echo "Starting $desc (storm-$stormSvc): "
-  su -s /bin/bash $stormUser -c "nohup storm $stormSvc >>$outFile 2>&1 &"
+  su -s /bin/bash - $stormUser -c "nohup storm $stormSvc >>$outFile 2>&1 &"
   RETVAL=$?
   return $RETVAL
 }

--- a/recipes/storm/storm-0.9.2_openbus-0.0.1-r1/rpm/sources/storm-kafka-dependencies.patch
+++ b/recipes/storm/storm-0.9.2_openbus-0.0.1-r1/rpm/sources/storm-kafka-dependencies.patch
@@ -1,6 +1,6 @@
 --- apache-storm-0.9.2-incubating-vanilla/external/storm-kafka/pom.xml	2014-06-13 22:35:14.000000000 +0200
-+++ apache-storm-0.9.2-incubating/external/storm-kafka/pom.xml	2014-08-12 09:53:39.486915032 +0200
-@@ -25,19 +25,51 @@
++++ apache-storm-0.9.2-incubating/external/storm-kafka/pom.xml	2014-08-27 11:46:28.307448765 +0200
+@@ -25,19 +25,50 @@
          <relativePath>../../pom.xml</relativePath>
      </parent>
  
@@ -43,7 +43,6 @@
 +		                    <exclude>org.slf4j:slf4j-simple</exclude>
 +		                </excludes>
 +	                    </artifactSet>
-+	                    <minimizeJar>true</minimizeJar>
 +	                </configuration>
 +                   </execution>
 +               </executions>
@@ -56,7 +55,7 @@
              <groupId>org.mockito</groupId>
              <artifactId>mockito-all</artifactId>
              <version>1.9.0</version>
-@@ -94,10 +126,8 @@
+@@ -94,10 +125,8 @@
          </dependency>
          <dependency>
              <groupId>org.apache.kafka</groupId>

--- a/recipes/storm/storm-0.9.2_openbus-0.0.1-r1/rpm/sources/storm-nimbus.init
+++ b/recipes/storm/storm-0.9.2_openbus-0.0.1-r1/rpm/sources/storm-nimbus.init
@@ -36,7 +36,7 @@ fi
 
 start() {
   echo "Starting $desc (storm-$stormSvc): "
-  su -s /bin/bash $stormUser -c "nohup storm $stormSvc >>$outFile 2>&1 &"
+  su -s /bin/bash - $stormUser -c "nohup storm $stormSvc >>$outFile 2>&1 &"
   RETVAL=$?
   return $RETVAL
 }

--- a/recipes/storm/storm-0.9.2_openbus-0.0.1-r1/rpm/sources/storm-supervisor-bash_profile
+++ b/recipes/storm/storm-0.9.2_openbus-0.0.1-r1/rpm/sources/storm-supervisor-bash_profile
@@ -1,0 +1,1 @@
+source /etc/default/storm

--- a/recipes/storm/storm-0.9.2_openbus-0.0.1-r1/rpm/sources/storm-supervisor.init
+++ b/recipes/storm/storm-0.9.2_openbus-0.0.1-r1/rpm/sources/storm-supervisor.init
@@ -36,7 +36,7 @@ fi
 
 start() {
   echo "Starting $desc (storm-$stormSvc): "
-  su -s /bin/bash $stormUser -c "nohup storm $stormSvc >>$outFile 2>&1 &"
+  su -s /bin/bash - $stormUser -c "nohup storm $stormSvc >>$outFile 2>&1 &"
   RETVAL=$?
   return $RETVAL
 }

--- a/recipes/storm/storm-0.9.2_openbus-0.0.1-r1/rpm/sources/storm-ui.init
+++ b/recipes/storm/storm-0.9.2_openbus-0.0.1-r1/rpm/sources/storm-ui.init
@@ -36,7 +36,7 @@ fi
 
 start() {
   echo "Starting $desc (storm-$stormSvc): "
-  su -s /bin/bash $stormUser -c "nohup storm $stormSvc >>$outFile 2>&1 &"
+  su -s /bin/bash - $stormUser -c "nohup storm $stormSvc >>$outFile 2>&1 &"
   RETVAL=$?
   return $RETVAL
 }

--- a/recipes/storm/storm-0.9.2_openbus-0.0.1-r1/rpm/sources/storm.default
+++ b/recipes/storm/storm-0.9.2_openbus-0.0.1-r1/rpm/sources/storm.default
@@ -1,4 +1,4 @@
 export STORM_DIR=/usr/lib/storm
 export USER_CONF_DIR=
-export CLUSTER_CONF_DIR=/etc/storm
+export CLUSTER_CONF_DIR=/etc/storm/conf
 

--- a/recipes/storm/storm-0.9.2_openbus-0.0.1-r1/rpm/sources/storm.default
+++ b/recipes/storm/storm-0.9.2_openbus-0.0.1-r1/rpm/sources/storm.default
@@ -1,4 +1,4 @@
 export STORM_DIR=/usr/lib/storm
-export USER_CONF_DIR=
+export USER_CONF_DIR=/etc/storm/conf
 export CLUSTER_CONF_DIR=/etc/storm/conf
 


### PR DESCRIPTION
This fix is related to #90 , and fix following bugs
- Storm supervisor daemon dies when an active topology is killed and
  can´t start until storm-local dir is removed
- Configuration path not set properly:Current /etc/storm
  Set to /etc/storm/conf
- storm kafka doesn't remove simbolic link after package remove
